### PR TITLE
Prevented a crash upon running the program when the Wallpapers directory is nonexistent.

### DIFF
--- a/run.py
+++ b/run.py
@@ -2,8 +2,8 @@ import os, sys
 from shutil import copyfile
 from PIL import Image
 
-packages_dir = os.path.expanduser("~\AppData\Local\Packages")
-dest_dir = os.path.expanduser("~\OneDrive\Pictures\Wallpapers")
+packages_dir = os.path.expanduser("~\\AppData\\Local\\Packages")
+dest_dir = os.path.expanduser("~\\OneDrive\\Pictures\\Wallpapers")
 extension = '.jpg'
 minimum_width = 1024
 
@@ -17,7 +17,7 @@ def test_image_width(full_file_name):
 
 for package_dir in os.listdir(packages_dir):
     if package_dir.startswith("Microsoft.Windows.ContentDeliveryManager"):
-        assets_path = os.path.join(packages_dir, package_dir, "LocalState\Assets")
+        assets_path = os.path.join(packages_dir, package_dir, "LocalState\\Assets")
         for file_name in os.listdir(assets_path):
             full_file_name = os.path.join(assets_path, file_name)
             if test_image_width(full_file_name):

--- a/run.py
+++ b/run.py
@@ -7,6 +7,10 @@ dest_dir = os.path.expanduser("~\\OneDrive\\Pictures\\Wallpapers")
 extension = '.jpg'
 minimum_width = 1024
 
+if not os.path.exists(dest_dir):
+    sys.stdout.write("creating directory %s\n" % dest_dir)
+    os.makedirs(dest_dir)
+
 def test_image_width(full_file_name):
     try:
         im = Image.open(full_file_name)


### PR DESCRIPTION
Previously, the program would crash on the call to `copyfile()` if the Wallpapers directory was not present. I added a check for such a condition so that the Wallpapers directory is created if it is nonexistent, thus avoiding the crash. I also escaped some backslashes in the pathname strings; while not strictly required in this case, it's good practice (and I wanted to please pylint).

I put the check before the function definition because it seemed logical to put the existence check close to the definition of `dest_dir` and away from the code relating to the actual image gathering process, but if you want the function definition before all global code, feel free to move the check as you see fit.
